### PR TITLE
Graceful shutdownをサポートする

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"log"
+	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/TechBowl-japan/go-stations/db"
@@ -49,8 +53,35 @@ func realMain() error {
 
 	// NOTE: 新しいエンドポイントの登録はrouter.NewRouterの内部で行うようにする
 	mux := router.NewRouter(todoDB)
+	server := &http.Server{
+		Addr:    port,
+		Handler: mux,
+	}
 
-	// TODO: サーバーをlistenする
+	ctx, stop := signal.NotifyContext(
+		context.Background(),
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+	defer stop()
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalln("main: could not listen on 8000, err =", err)
+		} else {
+			log.Printf("main: listen port is closed\n")
+		}
+	}()
+	<-ctx.Done()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatalln("main: could not gracefully shutdown the server, err =", err)
+	} else {
+		log.Printf("main: server is completely shutdown\n")
+	}
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, srv *http.Server) {
 		defer cancel()
 
 		if err := srv.Shutdown(ctx); err != nil {
-			log.Fatalln("main: could not gracefully shutdown the server, err =", err)
+			log.Printf("main: could not gracefully shutdown the server, err =%v\n", err)
 		} else {
 			log.Printf("main: server is completely shutdown\n")
 		}
@@ -94,7 +94,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, srv *http.Server) {
 
 	wg.Add(1)
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("main: could not listen on %v, err =%v\n", srv.Addr, err)
+		log.Printf("main: could not listen on %v, err =%v\n", srv.Addr, err)
 	} else {
 		log.Printf("main: listen port %v is closed\n", srv.Addr)
 	}

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func realMain() error {
 	defer stop()
 
 	var wg sync.WaitGroup
-	run(ctx, &wg, server)
+	go run(ctx, &wg, server)
 	wg.Wait()
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -65,8 +65,10 @@ func realMain() error {
 		syscall.SIGTERM,
 	)
 	defer stop()
-
 	var wg sync.WaitGroup
+
+	// NOTE: serverの数だけAddする
+	wg.Add(1)
 	go run(ctx, &wg, server)
 	wg.Wait()
 
@@ -92,7 +94,6 @@ func run(ctx context.Context, wg *sync.WaitGroup, srv *http.Server) {
 		}
 	}()
 
-	wg.Add(1)
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Printf("main: could not listen on %v, err =%v\n", srv.Addr, err)
 	} else {


### PR DESCRIPTION
- Graceful shutdownをサポートする
- 複数のHTTPサーバのGraceful shutdownをサポートする
- log.Fatalf の呼び出し(os.Exit(1)による終了)をやめ、defer関数が確実に呼ばれるようにする
- HTTPサーバをそれぞれ別のgoroutineで起動させる
- WaitGroup.Add と WaitGroup.Wait を別goroutineで呼ぶと、WaitがAddより先に実行されて待ち受けが正しくできない事がある
