### PR TITLE
Basic認証を実行するHTTPミドルウェアを追加する

### DIFF
--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -17,7 +17,7 @@ func NewBasicAuthCredential(userID, password string) (*BasicAuthCredential, erro
 		userID:   userID,
 		password: password,
 	}
-	if !cred.isValidCredential() {
+	if !cred.isValid() {
 		return nil, fmt.Errorf("与えられた認証情報は、Basic認証として不適切です")
 	}
 	return cred, nil
@@ -34,7 +34,7 @@ func NewBasicAuthMiddleware(cred BasicAuthCredential) *basicAuthMiddleware {
 	}
 }
 
-func (cred *BasicAuthCredential) isValidCredential() bool {
+func (cred *BasicAuthCredential) isValid() bool {
 	if cred.userID == "" || cred.password == "" {
 		return false
 	}

--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -17,8 +17,8 @@ func NewBasicAuthCredential(userID, password string) (*BasicAuthCredential, erro
 		userID:   userID,
 		password: password,
 	}
-	if !cred.isValid() {
-		return nil, fmt.Errorf("与えられた認証情報は、Basic認証として不適切です")
+	if err := cred.validate(); err != nil {
+		return nil, err
 	}
 	return cred, nil
 }
@@ -34,11 +34,11 @@ func NewBasicAuthMiddleware(cred BasicAuthCredential) *basicAuthMiddleware {
 	}
 }
 
-func (cred *BasicAuthCredential) isValid() bool {
+func (cred *BasicAuthCredential) validate() error {
 	if cred.userID == "" || cred.password == "" {
-		return false
+		return fmt.Errorf("与えられた認証情報は、Basic認証として不適切です")
 	}
-	return true
+	return nil
 }
 
 // ServeNext は、 h の前後で取得した情報を元に、 アクセスログを記録する。

--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// BasicAuthCredential はBasic認証の認証情報を表す。
+type BasicAuthCredential struct {
+	userID   string
+	password string
+}
+
+// NewBasicAuthCredential は、妥当性が保証された BasicAuthCredential を返す。
+func NewBasicAuthCredential(userID, password string) (*BasicAuthCredential, error) {
+	cred := &BasicAuthCredential{
+		userID:   userID,
+		password: password,
+	}
+	if !cred.isValidCredential() {
+		return nil, fmt.Errorf("与えられた認証情報は、Basic認証として不適切です")
+	}
+	return cred, nil
+}
+
+type basicAuthMiddleware struct {
+	cred BasicAuthCredential
+}
+
+// NewBasicAuthMiddleware は、Basic認証によるアクセス制限を行うミドルウェアを返す。
+func NewBasicAuthMiddleware(cred BasicAuthCredential) *basicAuthMiddleware {
+	return &basicAuthMiddleware{
+		cred: cred,
+	}
+}
+
+func (cred *BasicAuthCredential) isValidCredential() bool {
+	if cred.userID == "" || cred.password == "" {
+		return false
+	}
+	return true
+}
+
+// ServeNext は、 h の前後で取得した情報を元に、 アクセスログを記録する。
+func (m *basicAuthMiddleware) ServeNext(h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("Authentication\n")
+		h.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}

--- a/main.go
+++ b/main.go
@@ -52,8 +52,14 @@ func realMain() error {
 	}
 	defer todoDB.Close()
 
-	// NOTE: 新しいエンドポイントの登録はrouter.NewRouterの内部で行うようにする
-	mux := router.NewHandler(todoDB)
+	mux, err := router.NewHandlerWithBasicAuth(
+		todoDB,
+		os.Getenv("BASIC_AUTH_USER_ID"),
+		os.Getenv("BASIC_AUTH_PASSWORD"),
+	)
+	if err != nil {
+		return err
+	}
 	server := &http.Server{
 		Addr:    port,
 		Handler: mux,


### PR DESCRIPTION
- 認証範囲を限定するために、URLパスにプレフィックス(/api)を導入する
- /api 以下のパスに限定して、Basic認証を提供するミドルウェア(仮実装)を適用する
- 構造体名と関数名で伝える情報が重複しているため、関数名を変更する
- 妥当性検証の詳細は BasicAuthCredential が把握するべき情報であるため、エラーもそこで生成する
- Basic認証の認証処理を実装する。(チャレンジ応答が未実装のため、ブラウザからのアクセスには未対応)
