### PR TITLE
Basic認証のチャレンジを実装する

### DIFF
--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -9,23 +9,23 @@ const (
 	defaultRealm = "Authorization Required Area"
 )
 
-// BasicAuthCredential はBasic認証の認証情報を表す。
-type BasicAuthCredential struct {
+// BasicAuthInfo はBasic認証でサーバ側が保持する情報を表す。
+type BasicAuthInfo struct {
 	userID   string
 	password string
 	realm    string
 }
 
-// NewBasicAuthCredential は、妥当性が保証された BasicAuthCredential を返す。
+// NewBasicAuthInfo は、妥当性が保証された BasicAuthInfo を返す。
 //
 // レルムにはデフォルト値が指定される。
-func NewBasicAuthCredential(userID, password string) (*BasicAuthCredential, error) {
-	return NewBasicAuthCredentialWithRealm(userID, password, defaultRealm)
+func NewBasicAuthInfo(userID, password string) (*BasicAuthInfo, error) {
+	return NewBasicAuthInfoWithRealm(userID, password, defaultRealm)
 }
 
-// NewBasicAuthCredentialWithRealm は、レルムを指定した BasicAuthCredential を返す。
-func NewBasicAuthCredentialWithRealm(userID, password, realm string) (*BasicAuthCredential, error) {
-	cred := &BasicAuthCredential{
+// NewBasicAuthInfoWithRealm は、レルムを指定した BasicAuthInfo を返す。
+func NewBasicAuthInfoWithRealm(userID, password, realm string) (*BasicAuthInfo, error) {
+	cred := &BasicAuthInfo{
 		userID:   userID,
 		password: password,
 		realm:    realm,
@@ -37,24 +37,24 @@ func NewBasicAuthCredentialWithRealm(userID, password, realm string) (*BasicAuth
 }
 
 type basicAuthMiddleware struct {
-	cred BasicAuthCredential
+	cred BasicAuthInfo
 }
 
 // NewBasicAuthMiddleware は、Basic認証によるアクセス制限を行うミドルウェアを返す。
-func NewBasicAuthMiddleware(cred BasicAuthCredential) *basicAuthMiddleware {
+func NewBasicAuthMiddleware(cred BasicAuthInfo) *basicAuthMiddleware {
 	return &basicAuthMiddleware{
 		cred: cred,
 	}
 }
 
-func (cred *BasicAuthCredential) validate() error {
+func (cred *BasicAuthInfo) validate() error {
 	if cred.userID == "" || cred.password == "" {
 		return fmt.Errorf("与えられた認証情報は、Basic認証として不適切です")
 	}
 	return nil
 }
 
-func (cred *BasicAuthCredential) authenticate(r *http.Request) error {
+func (cred *BasicAuthInfo) authenticate(r *http.Request) error {
 	uid, passwd, ok := r.BasicAuth()
 	if !ok {
 		return fmt.Errorf("ユーザからの認証情報が取得できません")

--- a/handler/router/router.go
+++ b/handler/router/router.go
@@ -53,7 +53,7 @@ func NewHandlerWithBasicAuth(
 	todoDB *sql.DB,
 	userID, password string,
 ) (http.Handler, error) {
-	bac, err := middleware.NewBasicAuthCredentialWithRealm(
+	bac, err := middleware.NewBasicAuthInfoWithRealm(
 		userID,
 		password,
 		"go-stations-api",
@@ -71,7 +71,7 @@ func NewHandlerWithBasicAuth(
 
 func newHandler(
 	todoDB *sql.DB,
-	cred *middleware.BasicAuthCredential,
+	cred *middleware.BasicAuthInfo,
 	ms ...middleware.HTTPMiddleware,
 ) http.Handler {
 	mux := http.NewServeMux()

--- a/handler/router/router.go
+++ b/handler/router/router.go
@@ -53,7 +53,11 @@ func NewHandlerWithBasicAuth(
 	todoDB *sql.DB,
 	userID, password string,
 ) (http.Handler, error) {
-	bac, err := middleware.NewBasicAuthCredential(userID, password)
+	bac, err := middleware.NewBasicAuthCredentialWithRealm(
+		userID,
+		password,
+		"go-stations-api",
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Basic認証のチャレンジを実装する
- レルムは機密情報とは言えないため、Credential を Info に変更する
