### PR TITLE
コロンを含んだユーザIDを禁止する

### DIFF
--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -47,9 +47,10 @@ func NewBasicAuthMiddleware(cred BasicAuthInfo) *basicAuthMiddleware {
 	}
 }
 
+// NOTE: サーバ起動失敗時に表示される情報であり、エラー詳細を含んでもユーザに見えないため問題ない。
 func (cred *BasicAuthInfo) validate() error {
 	if cred.userID == "" || cred.password == "" {
-		return fmt.Errorf("与えられた認証情報は、Basic認証として不適切です")
+		return fmt.Errorf("Basic認証のユーザID/パスワードは、空文字以外を指定する必要があります")
 	}
 	return nil
 }

--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -51,6 +52,9 @@ func NewBasicAuthMiddleware(cred BasicAuthInfo) *basicAuthMiddleware {
 func (cred *BasicAuthInfo) validate() error {
 	if cred.userID == "" || cred.password == "" {
 		return fmt.Errorf("Basic認証のユーザID/パスワードは、空文字以外を指定する必要があります")
+	}
+	if strings.Contains(cred.userID, ":") {
+		return fmt.Errorf("Basic認証のユーザIDは、コロン(:)を含んではいけません")
 	}
 	return nil
 }


### PR DESCRIPTION
- 起動時に与えられるBasic認証の情報に関するエラーはユーザに見えないため、詳細に書いても問題ない
- コロンを含んだユーザIDは仕様上許可されていない。サーバ側で指定した場合にログイン不能になるため、指定した場合に起動できないようにする
